### PR TITLE
add quotation marks to publish command

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -45,7 +45,7 @@ Include the Facade:
 
 Publish vendor config and migration:
 
-    php artisan vendor:publish --provider=LukePOLO\LaraCart\LaraCartServiceProvider
+    php artisan vendor:publish --provider="LukePOLO\LaraCart\LaraCartServiceProvider"
     
 Look through the configuration options and change as needed.
 
@@ -53,6 +53,6 @@ Look through the configuration options and change as needed.
 ##Configuration
 LaraCart has a lot of configuration options, please make sure you run:
 
-    php artisan vendor:publish --provider=LukePOLO\LaraCart\LaraCartServiceProvider
+    php artisan vendor:publish --provider="LukePOLO\LaraCart\LaraCartServiceProvider"
     
 After please make sure you go through and customize for your needs


### PR DESCRIPTION
without them, the `php artisan vendor:publish` command will fail with `Unable to locate publishable resources.`

![Screenshot 2021-07-15 at 09 13 32](https://user-images.githubusercontent.com/1032474/125737987-de551c95-ad31-4f8a-a016-019bf1840ec4.png)
![Screenshot 2021-07-15 at 09 13 42](https://user-images.githubusercontent.com/1032474/125737989-2939ebde-88a0-45ae-be54-be6f6551aaaa.png)
